### PR TITLE
テスト依存パッケージのバージョン指定で警告を解消

### DIFF
--- a/BourbonAe.Core.Tests/BourbonAe.Core.Tests.csproj
+++ b/BourbonAe.Core.Tests/BourbonAe.Core.Tests.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <!-- xUnit packages for testing -->
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- テストプロジェクトの xUnit 関連パッケージと Microsoft.NET.Test.Sdk にバージョンを明示して警告を解消

## Testing
- `dotnet restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_b_689ed5af4ee883209160c0d716799ea2