### PR TITLE
fix: resolve test build errors

### DIFF
--- a/BourbonAe.Core.Tests/BourbonAe.Core.Tests.csproj
+++ b/BourbonAe.Core.Tests/BourbonAe.Core.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BourbonAe.Core.Tests/DataAccessServiceTests.cs
+++ b/BourbonAe.Core.Tests/DataAccessServiceTests.cs
@@ -4,6 +4,7 @@ using BourbonAe.Core.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace BourbonAe.Core.Tests


### PR DESCRIPTION
## Summary
- add missing Task namespace to DataAccessServiceTests
- include EF Core InMemory provider for test project

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_b_689ee1d59e0083209e98374d89b6d780