### PR TITLE
デザイン時 DbContext の生成を修正

### DIFF
--- a/BourbonAe.Core/Data/ApplicationDbContextFactory.cs
+++ b/BourbonAe.Core/Data/ApplicationDbContextFactory.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using System.IO;
+
+namespace BourbonAe.Core.Data;
+
+/// <summary>
+/// Design-time factory for creating <see cref="ApplicationDbContext"/> instances.
+/// This allows EF Core tools (e.g. <c>Add-Migration</c>) to instantiate the context
+/// without relying on the runtime dependency injection setup.
+/// </summary>
+public class ApplicationDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
+{
+    public ApplicationDbContext CreateDbContext(string[] args)
+    {
+        // Build configuration based on the appsettings files so migrations use
+        // the same connection string as the running application.
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile("appsettings.Development.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+        var connectionString = configuration.GetConnectionString("DefaultConnection");
+        optionsBuilder.UseSqlServer(connectionString);
+
+        return new ApplicationDbContext(optionsBuilder.Options);
+    }
+}
+

--- a/BourbonAe.Core/Services/Features/AESJ1110/Aesj1110Service.cs
+++ b/BourbonAe.Core/Services/Features/AESJ1110/Aesj1110Service.cs
@@ -1,12 +1,13 @@
 using Microsoft.EntityFrameworkCore;
 using BourbonAe.Core.Models.AESJ1110;
+using BourbonAe.Core.Data;
 using BourbonAe.Core.Data.Entities;
 namespace BourbonAe.Core.Services.Features.AESJ1110
 {
     public sealed class Aesj1110Service : IAesj1110Service
     {
-        private readonly DbContext _db;
-        public Aesj1110Service(DbContext db) => _db = db;
+        private readonly ApplicationDbContext _db;
+        public Aesj1110Service(ApplicationDbContext db) => _db = db;
         public async Task<IReadOnlyList<Aesj1110Row>> SearchAsync(Aesj1110Filter filter, CancellationToken ct = default)
         {
             IQueryable<Aesj1110Entity> q = _db.Set<Aesj1110Entity>().AsNoTracking();


### PR DESCRIPTION
## 概要
- IAesj1110Service の実装で `DbContext` ではなく `ApplicationDbContext` を注入するよう変更
- `ApplicationDbContextFactory` を追加し、`Add-Migration` 実行時に DbContext が生成できるよう対応

## テスト
- `dotnet build`
- `dotnet test`
- `dotnet ef migrations add TestMigration`（生成ファイルはコミットせず削除）

------
https://chatgpt.com/codex/tasks/task_b_689f2af26b4883208f7a6709c5475d66